### PR TITLE
Fix: Correct password handling in registration method

### DIFF
--- a/backend/src/Controllers/AuthController.php
+++ b/backend/src/Controllers/AuthController.php
@@ -59,7 +59,7 @@ class AuthController{
 		}
 
 		// Register new user
-		$userId = $userModel->registerUser($data->first_name, $data->last_name, $data->email, password_hash($data->password, PASSWORD_DEFAULT));
+		$userId = $userModel->registerUser($data->first_name, $data->last_name, $data->email, $data->password);
 
 		if ($userId) {
 			echo json_encode(['status' => 'valid', 'message' => 'User registered successfully']);


### PR DESCRIPTION
### Summary
This PR fixes an issue in the `AuthController` where the password was being hashed twice during user registration.

### Changes
- Updated the `register` method in `AuthController.php` to pass the plain-text password directly to the `UserModel`.

### Why This Fix is Necessary
- The double hashing caused the stored password to be invalid, preventing users from logging in after registration.